### PR TITLE
Separated PhotonVision from Limelight

### DIFF
--- a/src/main/java/frc/robot/BuildConstants.java
+++ b/src/main/java/frc/robot/BuildConstants.java
@@ -5,12 +5,12 @@ public final class BuildConstants {
     public static final String MAVEN_GROUP = "";
     public static final String MAVEN_NAME = "Flash-2023";
     public static final String VERSION = "unspecified";
-    public static final int GIT_REVISION = 168;
-    public static final String GIT_SHA = "b1d67f33b96e3bbe0dab3327d5bb97e70e6dc2af";
-    public static final String GIT_DATE = "2023-01-28 12:01:21 CST";
-    public static final String GIT_BRANCH = "main";
-    public static final String BUILD_DATE = "2023-01-28 12:11:01 CST";
-    public static final long BUILD_UNIX_TIME = 1674929461103L;
+    public static final int GIT_REVISION = 169;
+    public static final String GIT_SHA = "3e57fb81d5b6860d13c6d5663d5fe4a80854df83";
+    public static final String GIT_DATE = "2023-01-28 12:13:02 CST";
+    public static final String GIT_BRANCH = "Jonathan";
+    public static final String BUILD_DATE = "2023-01-28 15:54:23 CST";
+    public static final long BUILD_UNIX_TIME = 1674942863725L;
     public static final int DIRTY = 1;
 
     private BuildConstants() {}

--- a/src/main/java/frc/robot/pilot/PilotGamepad.java
+++ b/src/main/java/frc/robot/pilot/PilotGamepad.java
@@ -39,7 +39,7 @@ public class PilotGamepad extends Gamepad {
         gamepad.aButton.whileTrue(PilotCommands.aimPilotDrive(Math.PI * 1 / 2).withName("Snap 90"));
         // gamepad.bButton.whileTrue(PilotCommands.fpvPilotSwerve());
         gamepad.bButton.whileTrue(
-                PilotCommands.aimPilotDrive(() -> Robot.vision.getRadiansToTarget())
+                PilotCommands.aimPilotDrive(() -> Robot.vision.photonVision.getRadiansToTarget())
                         .withName("Aim to target"));
         // gamepad.xButton.whileTrue(new LockSwerve());
         /* get information about target and robot yaw */

--- a/src/main/java/frc/robot/vision/PhotonVision.java
+++ b/src/main/java/frc/robot/vision/PhotonVision.java
@@ -1,0 +1,188 @@
+package frc.robot.vision;
+
+import edu.wpi.first.math.Pair;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.util.Units;
+import edu.wpi.first.wpilibj.Timer;
+import frc.robot.Robot;
+import frc.robot.RobotTelemetry;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import org.photonvision.PhotonCamera;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+
+public class PhotonVision {
+    public final VisionConfig config;
+    public final RobotPoseEstimator poseEstimator;
+    public final PhotonCamera[] cameras;
+    public Pair<Pose3d, Double> currentPose;
+
+    private ArrayList<Pair<PhotonCamera, Transform3d>> cameraPairs;
+    private double yaw, pitch, area, poseAmbiguity, captureTime;
+    private int targetId;
+
+    // testing
+    private final DecimalFormat df = new DecimalFormat();
+    private double lastYaw = 0;
+    private boolean targetFound = true;
+
+    public PhotonVision() {
+        config = new VisionConfig();
+        cameraPairs = new ArrayList<Pair<PhotonCamera, Transform3d>>();
+        currentPose = new Pair<Pose3d, Double>(new Pose3d(0, 0, 0, new Rotation3d(0, 0, 0)), 0.0);
+
+        cameras =
+                new PhotonCamera[] {VisionConfig.LL.config.camera
+                    /* Add cameras here */
+                };
+        /* setting up the pair(s) of cameras and their 3d transformation from the center of the robot
+        to give to the pose estimator */
+        for (int i = 0; i < cameras.length; i++) {
+            cameraPairs.add(getCameraPair(getCameraConfig(i)));
+        }
+
+        /* Outdated use of PhotonPoseEstimator */
+        poseEstimator =
+                new RobotPoseEstimator(VisionConfig.tagMap, VisionConfig.strategy, cameraPairs);
+
+        // printing purposes
+        df.setMaximumFractionDigits(2);
+    }
+
+    public void update() {
+        currentPose = getEstimatedPose();
+
+        /* get targets & basic data from a single camera */
+        PhotonPipelineResult results = cameras[0].getLatestResult();
+        if (results.hasTargets()) {
+            PhotonTrackedTarget target = results.getBestTarget();
+            // negate it because the target.getYaw is the yaw of the robot from the target which is
+            // the opposite direction. Or photonvision yaw is CW+ CCW-
+            yaw = -target.getYaw();
+            pitch = target.getPitch();
+            area = target.getArea();
+            targetId = target.getFiducialId();
+            poseAmbiguity = target.getPoseAmbiguity();
+            captureTime = Timer.getFPGATimestamp() - (results.getLatencyMillis() / 1000d);
+
+            // printing
+            if (lastYaw == 0) {
+                lastYaw = yaw;
+            }
+
+            /* If robot has moved, print new target data */
+            if (Math.round(lastYaw) != Math.round(yaw)) {
+                // printDebug(targetId, yaw, pitch, area, poseAmbiguity, captureTime);
+            }
+
+            lastYaw = yaw;
+            targetFound = true;
+        } else {
+            // no target found
+            yaw = 0.0;
+            if (targetFound) {
+                RobotTelemetry.print("Lost target");
+                targetFound = false;
+            }
+        }
+    }
+
+    /**
+     * Gets the yaw of the target relative to the field for aiming.
+     *
+     * @return Yaw in radians
+     */
+    public double getRadiansToTarget() {
+        return Units.degreesToRadians(yaw) + Robot.swerve.getHeading().getRadians();
+    }
+
+    public double getYaw() {
+        return yaw;
+    }
+
+    /** Gets the camera capture time in seconds. */
+    public double getTimestampSeconds() {
+        return Timer.getFPGATimestamp() - (currentPose.getSecond().doubleValue() / 1000d);
+    }
+
+    /**
+     * Gets the estimated pose of the robot.
+     *
+     * @return the estimated pose of the robot
+     */
+    private Pair<Pose3d, Double> getEstimatedPose() {
+        return poseEstimator.update();
+    }
+
+    /**
+     * Projects 3d pose to 2d to compare against odometry estimate. Does not account for difference
+     * in rotation.
+     *
+     * @return whether or not the vision estimated pose is within 1 meter of the odometry estimated
+     *     pose
+     */
+    public boolean isValidPose() {
+        Pose2d pose = currentPose.getFirst().toPose2d();
+        Pose2d odometryPose = Robot.pose.getPosition();
+        return (Math.abs(pose.getX() - odometryPose.getX()) <= 1)
+                && (Math.abs(pose.getY() - odometryPose.getY()) <= 1);
+    }
+
+    /**
+     * Gets the camera pair for the pose estimator.
+     *
+     * @param cameraConfig the camera config
+     * @return the camera pair
+     */
+    private Pair<PhotonCamera, Transform3d> getCameraPair(CameraConfig config) {
+        return new Pair<PhotonCamera, Transform3d>(
+                config.camera,
+                new Transform3d(
+                        new Translation3d(
+                                config.cameraToRobotX,
+                                config.cameraToRobotY,
+                                config.cameraToRobotZ),
+                        new Rotation3d(
+                                config.cameraRollRadians,
+                                config.cameraPitchRadians,
+                                config.cameraYawRadians)));
+    }
+
+    /**
+     * Gets the camera config for the camera.
+     *
+     * @param cameraIndex the camera index
+     * @return the camera config
+     */
+    private CameraConfig getCameraConfig(int iteration) {
+        switch (iteration) {
+            case 0:
+                return VisionConfig.LL.config;
+                /* add camera configs here */
+            default:
+                RobotTelemetry.print("Something went wrong trying to get camera config");
+                return VisionConfig.LL.config;
+        }
+    }
+
+    private void printDebug() {
+        RobotTelemetry.print(
+                "Target ID: "
+                        + targetId
+                        + " | Target Yaw: "
+                        + df.format(yaw)
+                        + " | Pitch: "
+                        + df.format(pitch)
+                        + " | Area: "
+                        + df.format(area)
+                        + " | Pose Ambiguity: "
+                        + poseAmbiguity
+                        + " | Capture Time: "
+                        + df.format(captureTime));
+    }
+}

--- a/src/main/java/frc/robot/vision/Vision.java
+++ b/src/main/java/frc/robot/vision/Vision.java
@@ -1,72 +1,44 @@
 package frc.robot.vision;
 
 import edu.wpi.first.math.Pair;
-import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.networktables.DoubleArraySubscriber;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Robot;
-import frc.robot.RobotTelemetry;
 import java.text.DecimalFormat;
-import java.util.ArrayList;
-import org.photonvision.PhotonCamera;
-import org.photonvision.targeting.PhotonPipelineResult;
-import org.photonvision.targeting.PhotonTrackedTarget;
 
 public class Vision extends SubsystemBase {
-    public final VisionConfig config;
-    public final RobotPoseEstimator poseEstimator;
-    public final PhotonCamera[] cameras;
-    public Pair<Pose3d, Double> currentPose;
+    public PhotonVision photonVision;
 
-    private ArrayList<Pair<PhotonCamera, Transform3d>> cameraPairs;
-    private double yaw, pitch, area, poseAmbiguity, captureTime;
-    private int targetId;
     private NetworkTable table;
     private NetworkTableEntry tx, ty, ta;
     private DoubleArraySubscriber botPoseSub;
     private Transform3d botPoseTransform3d;
+    private Pair<Pose3d, Double> photonVisionPose;
 
     // testing
     private final DecimalFormat df = new DecimalFormat();
-    private double lastYaw = 0;
-    private boolean targetFound = true;
 
     public Vision() {
         setName("Vision");
-        config = new VisionConfig();
         table = NetworkTableInstance.getDefault().getTable("limelight");
         /* Creating bot pose sub */
         botPoseSub = table.getDoubleArrayTopic("botpose").subscribe(new double[] {});
-        cameraPairs = new ArrayList<Pair<PhotonCamera, Transform3d>>();
-        currentPose = new Pair<Pose3d, Double>(new Pose3d(0, 0, 0, new Rotation3d(0, 0, 0)), 0.0);
 
         /* Limelight NetworkTable Retrieval */
         tx = table.getEntry("tx");
         ty = table.getEntry("ty");
         ta = table.getEntry("ta");
 
-        cameras =
-                new PhotonCamera[] {VisionConfig.LL.config.camera
-                    /* Add cameras here */
-                };
-        /* setting up the pair(s) of cameras and their 3d transformation from the center of the robot
-        to give to the pose estimator */
-        for (int i = 0; i < cameras.length; i++) {
-            cameraPairs.add(getCameraPair(getCameraConfig(i)));
-        }
-
-        poseEstimator =
-                new RobotPoseEstimator(VisionConfig.tagMap, VisionConfig.strategy, cameraPairs);
+        /* PhotonVision Setup -- uncomment if running PhotonVision*/
+        // photonVision = new PhotonVision();
 
         // printing purposes
         df.setMaximumFractionDigits(2);
@@ -74,7 +46,18 @@ public class Vision extends SubsystemBase {
 
     @Override
     public void periodic() {
-        currentPose = getEstimatedPose();
+        /* PhotonVision Pose Estimation Retrieval */
+        if (photonVision != null) {
+            photonVision.update();
+            photonVisionPose = photonVision.currentPose;
+            /* Adding PhotonVision estimate to pose */
+            if (photonVision.isValidPose()) {
+                Robot.pose.addVisionMeasurement(
+                        photonVisionPose.getFirst().toPose2d(), photonVision.getTimestampSeconds());
+            }
+        }
+        
+        /* Limelight Pose Estimation */
         double x = tx.getDouble(0.0);
         double y = ty.getDouble(0.0);
         double area = ta.getDouble(0.0);
@@ -91,7 +74,7 @@ public class Vision extends SubsystemBase {
             SmartDashboard.putString("Bot2", df.format(robotPose[4]));
             SmartDashboard.putString("Bot3", df.format(robotPose[5]));
 
-            /* Creating Transform3d object from raw values */
+            /* Creating Transform3d object from raw values -- Rotation values could be in degrees which need to be converted*/
             botPoseTransform3d =
                     new Transform3d(
                             new Translation3d(robotPose[0], robotPose[1], robotPose[2]),
@@ -103,138 +86,7 @@ public class Vision extends SubsystemBase {
         SmartDashboard.putString("tagX", df.format(x));
         SmartDashboard.putString("tagY", df.format(y));
         SmartDashboard.putString("tagArea", df.format(area));
-        /* Adding vision estimate to pose */
-        // if(isValidPose()) {
-        //     Robot.pose.addVisionMeasurement(currentPose.getFirst().toPose2d(),
-        // getTimestampSeconds());
-        // }
 
-        /* get targets & basic data from a single camera */
-        PhotonPipelineResult results = cameras[0].getLatestResult();
-        if (results.hasTargets()) {
-            PhotonTrackedTarget target = results.getBestTarget();
-            // negate it because the target.getYaw is the yaw of the robot from the target which is
-            // the opposite direction. Or photonvision yaw is CW+ CCW-
-            yaw = -target.getYaw();
-            pitch = target.getPitch();
-            area = target.getArea();
-            targetId = target.getFiducialId();
-            poseAmbiguity = target.getPoseAmbiguity();
-            captureTime = Timer.getFPGATimestamp() - (results.getLatencyMillis() / 1000d);
 
-            // printing
-            if (lastYaw == 0) {
-                lastYaw = yaw;
-            }
-
-            /* If robot has moved, print new target data */
-            if (Math.round(lastYaw) != Math.round(yaw)) {
-                // printDebug(targetId, yaw, pitch, area, poseAmbiguity, captureTime);
-            }
-
-            lastYaw = yaw;
-            targetFound = true;
-        } else {
-            // no target found
-            yaw = 0.0;
-            if (targetFound) {
-                RobotTelemetry.print("Lost target");
-                targetFound = false;
-            }
-        }
-    }
-
-    /**
-     * Gets the yaw of the target relative to the field for aiming.
-     *
-     * @return Yaw in radians
-     */
-    public double getRadiansToTarget() {
-        return Units.degreesToRadians(yaw) + Robot.swerve.getHeading().getRadians();
-    }
-
-    public double getYaw() {
-        return yaw;
-    }
-
-    /** Gets the camera capture time in seconds. */
-    public double getTimestampSeconds() {
-        return Timer.getFPGATimestamp() - (currentPose.getSecond().doubleValue() / 1000d);
-    }
-
-    /**
-     * Gets the estimated pose of the robot.
-     *
-     * @return the estimated pose of the robot
-     */
-    private Pair<Pose3d, Double> getEstimatedPose() {
-        return poseEstimator.update();
-    }
-
-    /**
-     * Projects 3d pose to 2d to compare against odometry estimate. Does not account for difference
-     * in rotation.
-     *
-     * @return whether or not the vision estimated pose is within 1 meter of the odometry estimated
-     *     pose
-     */
-    private boolean isValidPose() {
-        Pose2d pose = currentPose.getFirst().toPose2d();
-        Pose2d odometryPose = Robot.pose.getPosition();
-        return (Math.abs(pose.getX() - odometryPose.getX()) <= 1)
-                && (Math.abs(pose.getY() - odometryPose.getY()) <= 1);
-    }
-
-    /**
-     * Gets the camera pair for the pose estimator.
-     *
-     * @param cameraConfig the camera config
-     * @return the camera pair
-     */
-    private Pair<PhotonCamera, Transform3d> getCameraPair(CameraConfig config) {
-        return new Pair<PhotonCamera, Transform3d>(
-                config.camera,
-                new Transform3d(
-                        new Translation3d(
-                                config.cameraToRobotX,
-                                config.cameraToRobotY,
-                                config.cameraToRobotZ),
-                        new Rotation3d(
-                                config.cameraRollRadians,
-                                config.cameraPitchRadians,
-                                config.cameraYawRadians)));
-    }
-
-    /**
-     * Gets the camera config for the camera.
-     *
-     * @param cameraIndex the camera index
-     * @return the camera config
-     */
-    private CameraConfig getCameraConfig(int iteration) {
-        switch (iteration) {
-            case 0:
-                return VisionConfig.LL.config;
-                /* add camera configs here */
-            default:
-                RobotTelemetry.print("Something went wrong trying to get camera config");
-                return VisionConfig.LL.config;
-        }
-    }
-
-    private void printDebug() {
-        RobotTelemetry.print(
-                "Target ID: "
-                        + targetId
-                        + " | Target Yaw: "
-                        + df.format(yaw)
-                        + " | Pitch: "
-                        + df.format(pitch)
-                        + " | Area: "
-                        + df.format(area)
-                        + " | Pose Ambiguity: "
-                        + poseAmbiguity
-                        + " | Capture Time: "
-                        + df.format(captureTime));
     }
 }

--- a/src/main/java/frc/robot/vision/VisionCommands.java
+++ b/src/main/java/frc/robot/vision/VisionCommands.java
@@ -15,16 +15,16 @@ public class VisionCommands {
                 () ->
                         RobotTelemetry.print(
                                 "Yaw (D): "
-                                        + Robot.vision.getYaw()
+                                        + Robot.vision.photonVision.getYaw()
                                         + "|| gyro (D): "
                                         + Robot.swerve.getHeading().getDegrees()
                                         + " || Aiming at: "
-                                        + (Robot.vision.getYaw()
+                                        + (Robot.vision.photonVision.getYaw()
                                                 + Robot.swerve.getHeading().getDegrees())));
     }
 
     public static Command printEstimatedPoseInfo() {
-        Pair<Pose3d, Double> pose = Robot.vision.currentPose;
+        Pair<Pose3d, Double> pose = Robot.vision.photonVision.currentPose;
         return new InstantCommand(
                 () ->
                         RobotTelemetry.print(


### PR DESCRIPTION
PhotonVision pose estimation can easily be toggled on or off without having to disable the entire vision subsystem. I haven't tested that PhotonVision would actually report correct values with this rearrangement, but this means that there are no errors being spammed in Driver Station whenever vision is running. 